### PR TITLE
Editing data marts

### DIFF
--- a/dbt/dbt_neobank/.sqlfluff
+++ b/dbt/dbt_neobank/.sqlfluff
@@ -1,0 +1,19 @@
+[sqlfluff]
+dialect = bigquery
+templater = dbt
+max_line_length = 120
+
+[sqlfluff:templater:dbt]
+project_dir = .
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.identifiers]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.functions]
+capitalisation_policy = lower
+
+[sqlfluff:rules:layout.long_lines]
+max_line_length = 120

--- a/dbt/dbt_neobank/dbt_project.yml
+++ b/dbt/dbt_neobank/dbt_project.yml
@@ -38,3 +38,6 @@ models:
     data_vault:
       +schema: neobank_data_vault
       +materialized: view
+
+vars:
+  load_date: '2025-07-01 00:00:00.000000 UTC'

--- a/dbt/dbt_neobank/models/data_vault/hubs/hub_notifications.sql
+++ b/dbt/dbt_neobank/models/data_vault/hubs/hub_notifications.sql
@@ -1,6 +1,6 @@
-SELECT
-    notification_id
-    ,md5(notification_id) AS notification_hk
-    ,TIMESTAMP('{{ var("load_date") }}') AS load_date
-    ,{{ record_source('stg_notifications') }} AS record_source
-FROM {{ ref('stg_notifications') }}
+select
+    notification_id,
+    md5(notification_id) as notification_hk,
+    timestamp('{{ var("load_date") }}') as load_date
+    ,{{ record_source('stg_notifications') }} as record_source
+from {{ ref('stg_notifications') }}

--- a/dbt/dbt_neobank/models/data_vault/hubs/hub_notifications.sql
+++ b/dbt/dbt_neobank/models/data_vault/hubs/hub_notifications.sql
@@ -1,6 +1,6 @@
 SELECT
     notification_id
     ,md5(notification_id) AS notification_hk
-    ,TIMESTAMP('2025-07-01 00:00:00.000000 UTC') AS load_date
+    ,TIMESTAMP('{{ var("load_date") }}') AS load_date
     ,{{ record_source('stg_notifications') }} AS record_source
 FROM {{ ref('stg_notifications') }}

--- a/dbt/dbt_neobank/models/data_vault/hubs/hub_transactions.sql
+++ b/dbt/dbt_neobank/models/data_vault/hubs/hub_transactions.sql
@@ -2,6 +2,6 @@
 SELECT
     transaction_id
     ,md5(cast(transaction_id as string)) as transaction_hk
-    ,timestamp('2025-07-01 00:00:00.000000 UTC') AS load_date
+    ,timestamp('{{ var("load_date") }}') AS load_date
     ,{{ record_source('stg_transactions') }} AS record_source
 FROM {{ ref('stg_transactions') }}

--- a/dbt/dbt_neobank/models/data_vault/hubs/hub_transactions.sql
+++ b/dbt/dbt_neobank/models/data_vault/hubs/hub_transactions.sql
@@ -1,7 +1,6 @@
-
-SELECT
-    transaction_id
-    ,md5(cast(transaction_id as string)) as transaction_hk
-    ,timestamp('{{ var("load_date") }}') AS load_date
-    ,{{ record_source('stg_transactions') }} AS record_source
-FROM {{ ref('stg_transactions') }}
+select
+    transaction_id,
+    md5(cast(transaction_id as string)) as transaction_hk,
+    timestamp('{{ var("load_date") }}') as load_date
+    ,{{ record_source('stg_transactions') }} as record_source
+from {{ ref('stg_transactions') }}

--- a/dbt/dbt_neobank/models/data_vault/hubs/hub_users.sql
+++ b/dbt/dbt_neobank/models/data_vault/hubs/hub_users.sql
@@ -1,7 +1,6 @@
-
-SELECT
-    user_id
-    ,md5(cast(user_id as string)) as user_hk
-    ,timestamp('{{ var("load_date") }}') AS load_date
-    ,{{ record_source('stg_users') }} AS record_source
-FROM {{ ref('stg_users') }}
+select
+    user_id,
+    md5(cast(user_id as string)) as user_hk,
+    timestamp('{{ var("load_date") }}') as load_date
+    ,{{ record_source('stg_users') }} as record_source
+from {{ ref('stg_users') }}

--- a/dbt/dbt_neobank/models/data_vault/hubs/hub_users.sql
+++ b/dbt/dbt_neobank/models/data_vault/hubs/hub_users.sql
@@ -2,6 +2,6 @@
 SELECT
     user_id
     ,md5(cast(user_id as string)) as user_hk
-    ,timestamp('2025-07-01 00:00:00.000000 UTC') AS load_date
+    ,timestamp('{{ var("load_date") }}') AS load_date
     ,{{ record_source('stg_users') }} AS record_source
 FROM {{ ref('stg_users') }}

--- a/dbt/dbt_neobank/models/data_vault/links/data_vault_links.yml
+++ b/dbt/dbt_neobank/models/data_vault/links/data_vault_links.yml
@@ -38,3 +38,23 @@ models:
       - name: record_source
         data_tests:
           - not_null
+
+  - name: link_user_device
+    description: link table connecting users and devices
+    columns:
+      - name: user_hk
+        data_tests:
+          - not_null
+      - name: device_hk
+        data_tests:
+          - not_null
+      - name: user_device_hk
+        data_tests:
+          - unique
+          - not_null
+      - name: load_date
+        data_tests:
+          - not_null
+      - name: record_source
+        data_tests:
+          - not_null

--- a/dbt/dbt_neobank/models/data_vault/links/link_user_device.sql
+++ b/dbt/dbt_neobank/models/data_vault/links/link_user_device.sql
@@ -1,18 +1,18 @@
 with device_with_user as (
-  select
-    d.device_id
-    ,u.user_id
-    ,md5(cast(u.user_id as string)) AS user_hk
-    ,md5(cast(d.device_id as string)) AS device_hk
-  from {{ ref('stg_devices') }} d
-  join {{ ref('stg_users') }} u
-    on d.user_id = u.user_id
+    select
+        d.device_id,
+        u.user_id,
+        md5(cast(u.user_id as string)) as user_hk,
+        md5(cast(d.device_id as string)) as device_hk
+    from {{ ref('stg_devices') }} as d
+    inner join {{ ref('stg_users') }} as u
+        on d.user_id = u.user_id
 )
 
 select
-  md5(concat(user_hk, device_hk)) AS user_device_hk
-  ,user_hk
-  ,device_hk
-  ,timestamp('{{ var("load_date") }}') AS load_date
-  ,{{ record_source('stg_devices') }} AS record_source
+    md5(concat(user_hk, device_hk)) as user_device_hk,
+    user_hk,
+    device_hk,
+    timestamp('{{ var("load_date") }}') as load_date
+    ,{{ record_source('stg_devices') }} as record_source
 from device_with_user

--- a/dbt/dbt_neobank/models/data_vault/links/link_user_device.sql
+++ b/dbt/dbt_neobank/models/data_vault/links/link_user_device.sql
@@ -1,0 +1,18 @@
+with device_with_user as (
+  select
+    d.device_id
+    ,u.user_id
+    ,md5(cast(u.user_id as string)) AS user_hk
+    ,md5(cast(d.device_id as string)) AS device_hk
+  from {{ ref('stg_devices') }} d
+  join {{ ref('stg_users') }} u
+    on d.user_id = u.user_id
+)
+
+select
+  md5(concat(user_hk, device_hk)) AS user_device_hk
+  ,user_hk
+  ,device_hk
+  ,timestamp('{{ var("load_date") }}') AS load_date
+  ,{{ record_source('stg_devices') }} AS record_source
+from device_with_user

--- a/dbt/dbt_neobank/models/data_vault/links/link_user_notification.sql
+++ b/dbt/dbt_neobank/models/data_vault/links/link_user_notification.sql
@@ -1,19 +1,18 @@
-WITH notifications_with_user AS (
-  SELECT
-    n.notification_id
-    ,u.user_id
-    ,md5(cast(u.user_id as string)) AS user_hk
-    ,md5(cast(notification_id as string)) AS notification_hk
-  FROM {{ ref('stg_notifications') }} n
-  JOIN {{ ref('stg_users') }} u
-    ON n.user_id = u.user_id
+with notifications_with_user as (
+    select
+        n.notification_id,
+        u.user_id,
+        md5(cast(u.user_id as string)) as user_hk,
+        md5(cast(n.notification_id as string)) as notification_hk
+    from {{ ref('stg_notifications') }} as n
+    inner join {{ ref('stg_users') }} as u
+        on n.user_id = u.user_id
 )
 
-
-SELECT
-  md5(concat(user_hk,notification_hk)) AS user_notification_hk
-  ,user_hk
-  ,notification_hk
-  ,timestamp('{{ var("load_date") }}') AS load_date
-  ,{{ record_source('stg_notifications') }} AS record_source
-FROM notifications_with_user
+select
+    md5(concat(n.user_hk, n.notification_hk)) as user_notification_hk,
+    n.user_hk,
+    n.notification_hk,
+    timestamp('{{ var("load_date") }}') as load_date
+    ,{{ record_source('stg_notifications') }} as record_source
+from notifications_with_user as n

--- a/dbt/dbt_neobank/models/data_vault/links/link_user_notification.sql
+++ b/dbt/dbt_neobank/models/data_vault/links/link_user_notification.sql
@@ -14,6 +14,6 @@ SELECT
   md5(concat(user_hk,notification_hk)) AS user_notification_hk
   ,user_hk
   ,notification_hk
-  ,timestamp('2025-07-01 00:00:00.000000 UTC') AS load_date
-  ,{{ record_source('stg_transactions') }} AS record_source
+  ,timestamp('{{ var("load_date") }}') AS load_date
+  ,{{ record_source('stg_notifications') }} AS record_source
 FROM notifications_with_user

--- a/dbt/dbt_neobank/models/data_vault/links/link_user_transaction.sql
+++ b/dbt/dbt_neobank/models/data_vault/links/link_user_transaction.sql
@@ -14,6 +14,6 @@ SELECT
   md5(concat(user_hk,transaction_hk)) AS user_transaction_hk
   ,user_hk
   ,transaction_hk
-  ,timestamp('2025-07-01 00:00:00.000000 UTC') AS load_date
+  ,timestamp('{{ var("load_date") }}') AS load_date
   ,{{ record_source('stg_transactions') }} AS record_source
 FROM transactions_with_user

--- a/dbt/dbt_neobank/models/data_vault/links/link_user_transaction.sql
+++ b/dbt/dbt_neobank/models/data_vault/links/link_user_transaction.sql
@@ -1,19 +1,18 @@
-WITH transactions_with_user AS (
-  SELECT
-    t.transaction_id
-    ,u.user_id
-    ,md5(cast(u.user_id as string)) AS user_hk
-    ,md5(cast(transaction_id as string)) AS transaction_hk
-  FROM {{ ref('stg_transactions') }} t
-  JOIN {{ ref('stg_users') }} u
-    ON t.user_id = u.user_id
+with transactions_with_user as (
+    select
+        t.transaction_id,
+        u.user_id,
+        md5(cast(u.user_id as string)) as user_hk,
+        md5(cast(t.transaction_id as string)) as transaction_hk
+    from {{ ref('stg_transactions') }} as t
+    inner join {{ ref('stg_users') }} as u
+        on t.user_id = u.user_id
 )
 
-
-SELECT
-  md5(concat(user_hk,transaction_hk)) AS user_transaction_hk
-  ,user_hk
-  ,transaction_hk
-  ,timestamp('{{ var("load_date") }}') AS load_date
-  ,{{ record_source('stg_transactions') }} AS record_source
-FROM transactions_with_user
+select
+    md5(concat(t.user_hk, t.transaction_hk)) as user_transaction_hk,
+    t.user_hk,
+    t.transaction_hk,
+    timestamp('{{ var("load_date") }}') as load_date
+    ,{{ record_source('stg_transactions') }} as record_source
+from transactions_with_user as t

--- a/dbt/dbt_neobank/models/staging/staging.yml
+++ b/dbt/dbt_neobank/models/staging/staging.yml
@@ -13,6 +13,11 @@ models:
           data_tests:
           - unique
           - not_null
+        - name: device_id
+          description: device identifier - generated surrogate key from device and user_id.
+          data_tests:
+            - unique
+            - not_null
 
 
   - name: stg_notifications

--- a/dbt/dbt_neobank/models/staging/stg_devices.sql
+++ b/dbt/dbt_neobank/models/staging/stg_devices.sql
@@ -1,5 +1,5 @@
-SELECT
-  user_id
-  ,device_type
-  ,{{ dbt_utils.generate_surrogate_key(['user_id', 'device_type']) }} AS device_id
-FROM {{ source('raw', 'devices') }}
+select
+    user_id,
+    device_type,
+    {{ dbt_utils.generate_surrogate_key(['user_id', 'device_type']) }} as device_id
+from {{ source('raw', 'devices') }}

--- a/dbt/dbt_neobank/models/staging/stg_devices.sql
+++ b/dbt/dbt_neobank/models/staging/stg_devices.sql
@@ -1,4 +1,5 @@
 SELECT
   user_id
   ,device_type
+  ,{{ dbt_utils.generate_surrogate_key(['user_id', 'device_type']) }} AS device_id
 FROM {{ source('raw', 'devices') }}

--- a/dbt/dbt_neobank/models/staging/stg_notifications.sql
+++ b/dbt/dbt_neobank/models/staging/stg_notifications.sql
@@ -1,10 +1,9 @@
-
 select
-        reason
-        ,channel
-        ,status
-        ,user_id
-        --,timestamp_micros(created_date) as created_at
-        ,timestamp_micros(cast(created_date / 1000 as int64)) as created_at
-        ,user_id || '_' || timestamp_micros(cast(created_date / 1000 as int64)) || '_' || reason AS notification_id
+    reason,
+    channel,
+    status,
+    user_id,
+    --,timestamp_micros(created_date) as created_at
+    timestamp_micros(cast(created_date / 1000 as int64)) as created_at,
+    user_id || '_' || timestamp_micros(cast(created_date / 1000 as int64)) || '_' || reason as notification_id
 from {{ source('raw', 'notifications') }}

--- a/dbt/dbt_neobank/models/staging/stg_transactions.sql
+++ b/dbt/dbt_neobank/models/staging/stg_transactions.sql
@@ -1,13 +1,13 @@
 select
-        transaction_id
-        ,transactions_type as transaction_type
-        ,transactions_currency as transaction_currency
-        ,amount_usd
-        ,transactions_state as transaction_state
-        ,ea_cardholderpresence
-        ,ea_merchant_country
-        ,direction
-        ,user_id
-        ,timestamp_micros(cast(created_date / 1000 as int64)) as created_at
+    transaction_id,
+    transactions_type as transaction_type,
+    transactions_currency as transaction_currency,
+    amount_usd,
+    transactions_state as transaction_state,
+    ea_cardholderpresence,
+    ea_merchant_country,
+    direction,
+    user_id,
+    timestamp_micros(cast(created_date / 1000 as int64)) as created_at
 
 from {{ source('raw', 'transactions') }}

--- a/dbt/dbt_neobank/models/staging/stg_users.sql
+++ b/dbt/dbt_neobank/models/staging/stg_users.sql
@@ -1,11 +1,11 @@
 select
-        user_id
-        ,birth_year
-        ,country
-        ,timestamp_micros(cast(created_date / 1000 as int64)) as created_at
-        ,plan
-        ,user_settings_crypto_unlocked as crypto_unlocked
-        ,attributes_notifications_marketing_push as marketing_push
-        ,attributes_notifications_marketing_email as marketing_email
-        ,num_contacts
+    user_id,
+    birth_year,
+    country,
+    plan,
+    user_settings_crypto_unlocked as crypto_unlocked,
+    attributes_notifications_marketing_push as marketing_push,
+    attributes_notifications_marketing_email as marketing_email,
+    num_contacts,
+    timestamp_micros(cast(created_date / 1000 as int64)) as created_at
 from {{ source('raw', 'users') }}

--- a/dbt/pyproject.toml
+++ b/dbt/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
 [tool.poetry]
 package-mode = false
 
+[tool.poetry.group.dev.dependencies]
+sqlfluff = "^3.4.2"
+sqlfluff-templater-dbt = "^3.4.2"
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Added variable load_date to all files it is used.
We can also add device_id as a surrogate key and create a link_user_device if we want to also track historical changes in user devices in our data model. - This is optional from my side cause I have not studied the Data Vault Architecture much.
Added SQLFLUFF as linter to our project to enforce standardization in our SQL style. It enforces developers to use lower case and enter a maximum of 120 characters length lines currently. We can extend properties in need.  In Big Query lower case is not a very restricted standard but in Snowflake it is. In order to arrange platform independency we can use this as a standard as explained in chatGBT as below:
_"Use lowercase consistently in BigQuery unless you intentionally want to preserve casing in output (like AS "MyColumn"). This helps avoid issues across tools, UIs, and workflows — especially when moving between systems like Snowflake and BigQuery_."

I know that we learned to use upper case in keywords as a native SQL standard. But in the industry lower case is preferred for consistency and compatibility.

You can use the new linter as:
> sqlfluff lint models/<path_to_sql_file>

This shows you the issues it runs into and to fix them, you can use:
> sqlfluff fix models/<path_to_sql_file>

You can directly also run it to check all the models as:
> sqlfluff lint models